### PR TITLE
Fixed how the MQTT message with invalid JSON payload is handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,6 +250,7 @@ server.on('published', function (packet, client) {
   }
   catch (e) {
     logger.warn('Payload is not valid JSON. Ignoring.', packet.payload.toString(), e);
+    return;
   }
 
   logger.debug('Published', packet.topic, data, client.id);


### PR DESCRIPTION
Now, the iot-agent aborts the processing of a message with invalid
JSON payload.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
The iot-agent continues processing a message with invalid JSON payload when it should discard.


* **What is the new behavior (if this is a feature change)?**
The iot-agent stops processing a MQTT valid when it detects that the payload has invalid JSON.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No.

* **Other information**:
