### PR TITLE
Fix travis publish image tag latest

### DIFF
--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -ex
+if [ $TRAVIS_PULL_REQUEST == false ] ; then
+  version="latest"
+  if [ $TRAVIS_BRANCH != "master" ] ; then
+    version=$TRAVIS_BRANCH
+  fi
 
-version="latest"
-if [ $TRAVIS_BRANCH != "master" ] ; then
-  version=$TRAVIS_BRANCH
+  tag=${TRAVIS_REPO_SLUG}:$version
+
+  docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+  docker tag ${TRAVIS_REPO_SLUG} ${tag}
+  docker push $tag
 fi
-
-tag=${TRAVIS_REPO_SLUG}:$version
-
-docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-docker tag ${TRAVIS_REPO_SLUG} ${tag}
-docker push $tag
-


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduce fix to travis doesn't push new image with tag 'latest" when a PR is created.


* **What is the current behavior?** (You can also link to an open issue here)
When a PR is created, travis push new image with tag "latest" to docker hub.


* **What is the new behavior (if this is a feature change)?**
When a PR is created, travis doesn't push new image with tag "latest" to docker hub.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is child of dojot/dojot#722

* **Other information**:
