### PR TITLE
Reduce docker image size, fixing publish log message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM node:8
+FROM node:8.14.0-alpine
+
+RUN apk add git python make bash gzip gcc g++
+RUN apk --no-cache add gcc g++ musl-dev make python bash zlib-dev
 
 WORKDIR /opt
 
 # the following is required for mosca to install correctly
-RUN apt-get update && apt-get install libzmq-dev -y
+# RUN apk update && apk add zeromq-dev
 
-RUN apt-get update \
-	&& apt-get install  -y --no-install-recommends python-openssl python-pip \
+RUN apk update \
+	&& apk add -y --no-install-recommends py-openssl py-pip \
 	&& pip install requests kafka\
-	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
 ADD ./*.json /opt/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apk --no-cache add git gcc g++ musl-dev make python bash zlib-dev
 WORKDIR /opt
 
 # the following is required for mosca to install correctly
-# RUN apk update && apk add zeromq-dev
 
 RUN apk update \
 	&& apk add -y --no-install-recommends py-openssl py-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:8.14.0-alpine
 
-RUN apk add git python make bash gzip gcc g++
-RUN apk --no-cache add gcc g++ musl-dev make python bash zlib-dev
+RUN apk --no-cache add git gcc g++ musl-dev make python bash zlib-dev
 
 WORKDIR /opt
 

--- a/index.js
+++ b/index.js
@@ -291,7 +291,7 @@ server.on('published', function (packet, client) {
     return;
   }
 
-  logger.debug('Published', packet.topic, data, client.id);
+  logger.debug(`Published data: ${packet.payload.toString()}, client: ${client.id}, topic: ${packet.topic}`);
 
   //TODO: support only ISO string???
   let metadata = {};


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR changes the base image for iotagent-mosca to Alpine (which is much smaller in comparison with what we have been using). Also, it adds a log when the message is published with success.


* **What is the current behavior?** (You can also link to an open issue here)
Docker image is prone to updates (node:8 was recently updated to Debian stretch) When the message is published with success, it does not have a log with data. 


* **What is the new behavior (if this is a feature change)?**
Selected a more "fixed" base image and now when the message is published with success, It have a log with data. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is child of dojot/dojot#797

* **Other information**:
