### PR TITLE
fix: Hardcoded Hostnames for TLS

### DIFF
--- a/certUtils.py
+++ b/certUtils.py
@@ -32,7 +32,6 @@ def saveCRT(filename, rawCRT):
 def generateCSR(CName, privateKeyFile, csrFileName, dnsname=None, ipaddr=None):
     # based on https://github.com/cjcotton/python-csr
 
-
     if dnsname is None:
         dnsname = []
 

--- a/conf.py
+++ b/conf.py
@@ -9,7 +9,7 @@ keyLength = int(os.environ.get("MQTTREST_KEY_LENGHT", 2048))
 
 kafkaHost = os.environ.get("MQTTREST_KAFKA_HOST", "kafka:9092")
 
-subjectAltNameDnsList = os.environ.get("X509EXT_DNS_CSR_LIST", "mqtt,mosca,localhost").split(',')
+subjectAltNameDnsList = os.environ.get("MOSCA_TLS_DNS_LIST", "mqtt,mosca,localhost").split(',')
 
 ACLfilePath = "/opt/iot-agent/mosca/certs/access.acl"
 certsDir = "/opt/iot-agent/mosca/certs/"

--- a/conf.py
+++ b/conf.py
@@ -9,5 +9,7 @@ keyLength = int(os.environ.get("MQTTREST_KEY_LENGHT", 2048))
 
 kafkaHost = os.environ.get("MQTTREST_KAFKA_HOST", "kafka:9092")
 
+subjectAltNameDnsList = os.environ.get("X509EXT_DNS_CSR_LIST", "mqtt,mosca,localhost").split(',')
+
 ACLfilePath = "/opt/iot-agent/mosca/certs/access.acl"
 certsDir = "/opt/iot-agent/mosca/certs/"

--- a/initialConf.py
+++ b/initialConf.py
@@ -25,7 +25,7 @@ def generateCSR():
         certUtils.generateCSR(CName='mosca',
                               privateKeyFile=conf.certsDir + "/mosca.key",
                               csrFileName=conf.certsDir + "/mosca.csr",
-                              dnsname=['mqtt', 'mosca', 'localhost'])
+                              dnsname=conf.subjectAltNameDnsList)
 
 
 def askCertSign():


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The iotagent has hardcoded acceptable hostnames in case secure MQTT is used.


* **What is the new behavior (if this is a feature change)?**
Any hostname should be accepted by configuration (env variables) 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#1166

* **Other information**:
